### PR TITLE
fix: added keepAliveagent true option to agent because axios may clos…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ class Client {
   ) {}
 
   static create(options: ConnectionOptions): Client {
-    const agent = new https.Agent(options.ssl ?? {});
+    const agent = new https.Agent({...(options.ssl ?? {}), keepAlive: true});
 
     const clientConfig: AxiosRequestConfig = {
       baseURL: options.server ?? DEFAULT_SERVER,


### PR DESCRIPTION
…e the connection running on azure function app

Azure function app service has limited outbond ports. If too many requests are made consecutively, axios tend to close the connection if couldn't find an available port, instead waiting. 